### PR TITLE
Convert meta information of Openalea package in json schema according to IPM decision json schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # DSS : An open source library for Openalea IPM-Decision DSS
 
-**Authors:** Marc LABADIE, Christophe Pradal, Christian Fournier, Corrine Robert   
-**Mainteners:**   
+**Authors:** 
+* Marc LABADIE (marc.labadie@inrae.fr)
+* Christophe Pradal (christophe.pradal@cirad.fr)
+* Christian Fournier (christian.fournier@inrae.fr) 
+* Corinne Robert (corinne.robert@inrae.fr)
+
 **Institutes** : INRA, CIRAD  
-**Licence:** [CeCILL-C](/DSS/LICENSE.txt)  
-**Status:** Python package
+**Licence:** [CeCILL-C](https://raw.githubusercontent.com/H2020-IPM-openalea/DSS/master/LICENSE.txt)  
+**Status:** Python package  
+**Citation:**
 
 ## About
 
@@ -16,7 +21,23 @@ Repository containing DSS model of openalea for [H2020 IPM-Decision Project](htt
 
 ### Installation
 
+* **Install conda**  
+Follow official website instruction to install miniconda : http://conda.pydata.org/miniconda.html
+
+* **DSS package installation:**
+
+```
+conda create -n dss -c conda-forge python=2.7
+conda activate dss
+conda install -c conda-forge -c openalea astk  
+```
+
 ### Requierements
+* python 2.7 
+* astk
 
 ### Documentation
+
+Not documention available for the moment
+
 

--- a/schema.py
+++ b/schema.py
@@ -10,98 +10,126 @@ class MyEncoder(JSONEncoder):
         return str(o)
 
 
-def json_convert(package_name, module_name):
-    ''' convert openalea metainfo package and module in json
+pm = alea.load_package_manager()
+factory = pm['dss']
+name = 'dss_model'
+
+def package_metainfo(factory):
+    """
+    Transform package meta-information in Ordered Dict
     
     parameters:
     -----------
-       package_name: name of package to convert (type:string)
-       module_name : name of python module of package (type:string)
+        factory: package name
+    """
+    identifier = NotImplemented
+    name = factory.name
+    description = factory.metainfo['description'] # optional no ask by ipm
+    version = factory.metainfo['version']
+    Authors = factory.metainfo['authors']
+    url = factory.metainfo['url']
+    languages = NotImplemented
+    organization = {"name" : factory.metainfo["institutes"], 
+                    "country" : NotImplemented, 
+                    "address" : NotImplemented, 
+                    "postal_code" : NotImplemented, 
+                    "city" : NotImplemented, 
+                    "email" : NotImplemented, 
+                    "url" : NotImplemented}
+    license = factory.metainfo['license'] # optional no ask by ipm
+
+    return OrderedDict(identifier = identifier,
+                       name = name,
+                       description = description,
+                       version = version,
+                       Authors = Authors,  
+                       url = url, 
+                       languages = languages,
+                       organization = organization,
+                       license = license)
+
+def model_metainfo(factory,name):
+    """Transform a factory into an OrderedDict"""
+    name = factory[name].name
+    identifier = NotImplemented 
+    version = NotImplemented
+    type_of_decision = NotImplemented
+    type_of_output = NotImplemented
+    description_URL = NotImplemented
+    description = factory[name].description
+    citation = NotImplemented
+    execution = {"type": NotImplemented,
+                "endpoints": NotImplemented,
+                "form_method": NotImplemented,
+                "content_type": NotImplemented,
+                "input_schema": factory[name].get_writer()}
+    inputs = factory[name].inputs
+    authors = {"name":factory[name].get_authors(),
+            "email": NotImplemented,
+            "organization":factory.metainfo["institutes"]}
+    pests = NotImplemented
+    crops = NotImplemented
+    keywords = NotImplemented
+    output = {"warning_status_interpretation": NotImplemented,
+            "result_parameters": {"id": NotImplemented , 
+                                "title": factory[name].outputs[0]['name'],
+                                "description": factory[name].outputs[0]['desc']}}
+    valid_spatial = {"countries": NotImplemented,
+                    "geoJson": NotImplemented}
     
-    Return:
+    return OrderedDict(name = name, 
+                       identifier = identifier, 
+                       version= version,
+                       type_of_decision = type_of_decision,
+                       type_of_output = type_of_output,
+                       description_URL = description_URL,
+                       description = description,
+                       citation = citation,
+                       execution = execution,
+                       input = inputs,
+                       authors=authors, 
+                       pests = pests,
+                       crops = crops,
+                       keywords = keywords,
+                       output = output,
+                       valid_spatial = valid_spatial
+                       )
+
+
+dss = package_metainfo(factory)
+model = model_metainfo(factory, name)
+
+def json_read(obj):
+    '''
+    print Ordered dict in json
+    
+    Parameters:
+    -----------
+        obj:  OrderedDict issue from DSS and/or DSSModel function
+
+    return:
     -------
-       print of metainformation in json according to IPM schema
+        print in json format of OpenAlea package and model for DSS
+    ''' 
+    print(json.dumps(obj,indent=4,sort_keys=True, cls=MyEncoder))
+
+json_read(obj=(dss,model))
+
+def json_write(obj, filename):
+    ''' 
+    Create json file
+    
+    Parameters:
+    -----------
+        obj: OrderedDict issue from DSS and/or DSSModel function
+        filname: name of json file (filename must be finish by extension .json)
 
     '''
-    pm = alea.load_package_manager()
-    
-    factory = pm[package_name]
-    name = module_name
+    with open(filename, 'w') as f:
+        f.write(json.dumps(obj,f,indent=4,sort_keys=True,cls=MyEncoder))
 
-    def DSS(factory):
-        """Transform package meta-information in Ordered Dict"""
-        identifier = NotImplemented
-        name = factory.name
-        description = factory.metainfo['description'] # optional no ask by ipm
-        version = factory.metainfo['version']
-        Authors = factory.metainfo['authors']
-        url = factory.metainfo['url']
-        languages = NotImplemented
-        organization = {"name" : factory.metainfo["institutes"], 
-                        "country" : NotImplemented, 
-                        "address" : NotImplemented, 
-                        "postal_code" : NotImplemented, 
-                        "city" : NotImplemented, 
-                        "email" : NotImplemented, 
-                        "url" : NotImplemented}
-        license = factory.metainfo['license'] # optional no ask by ipm
-    
-        return OrderedDict(identifier = identifier,
-                           name = name,
-                           description = description,
-                           version = version,
-                           Authors = Authors,  
-                           url = url, 
-                           languages = languages,
-                           organization = organization,
-                           license = license)
+#json_write(obj=(dss, model),filename='DSS_package.json')
 
-    def DSSModel(factory,name):
-        """Transform a factory into an OrderedDict"""
-        name = factory[name].name
-        identifier = NotImplemented 
-        version = NotImplemented
-        type_of_decision = NotImplemented
-        type_of_output = NotImplemented
-        description_URL = NotImplemented
-        description = factory[name].description
-        citation = NotImplemented
-        execution = {"type": NotImplemented,
-                    "endpoints": NotImplemented,
-                    "form_method": NotImplemented,
-                    "content_type": NotImplemented,
-                    "input_schema": factory[name].get_writer()}
-        inputs = factory[name].inputs
-        authors = [{"name":factory[name].get_authors(),
-                "email": NotImplemented,
-                "organization":factory.metainfo["institutes"]}
-                ]
-        pests = NotImplemented
-        crops = NotImplemented
-        keywords = NotImplemented
-        output = {"warning_status_interpretation": NotImplemented,
-                "result_parameters": [{"id": NotImplemented , 
-                                    "title": factory[name].outputs[0]['name'],
-                                    "description": factory[name].outputs[0]['desc']}]}
-        valid_spatial = {"countries": NotImplemented,
-                        "geoJson": NotImplemented}
-        
-        return OrderedDict(name = name, 
-                        identifier = identifier, 
-                        version= version,
-                        type_of_decision = type_of_decision,
-                        type_of_output = type_of_output,
-                        description_URL = description_URL,
-                        description = description,
-                        citation = citation,
-                        execution = execution,
-                        input = inputs,
-                        authors=authors, 
-                        pests = pests,
-                        crops = crops,
-                        keywords = keywords,
-                        output = output,
-                        valid_spatial = valid_spatial
-                        ) 
-    
-    print json.dumps({"DSS":DSS(factory), "models":[DSSModel(factory,name)]}, indent=4, sort_keys=True, cls=MyEncoder)
+
+
+

--- a/schema.py
+++ b/schema.py
@@ -62,7 +62,7 @@ def model_metainfo(factory,name):
                 "endpoints": NotImplemented,
                 "form_method": NotImplemented,
                 "content_type": NotImplemented,
-                "input_schema": factory[name].get_writer()}
+                "input_schema": NotImplemented} #factory[name].get_writer()}
     inputs = factory[name].inputs
     authors = {"name":factory[name].get_authors(),
             "email": NotImplemented,
@@ -122,7 +122,7 @@ def json_write(obj, filename):
     Parameters:
     -----------
         obj: OrderedDict issue from DSS and/or DSSModel function
-        filname: name of json file (filename must be finish by extension .json)
+        filname: (string) name of json file (filename must be finish by extension .json)
 
     '''
     with open(filename, 'w') as f:

--- a/schema.py
+++ b/schema.py
@@ -22,20 +22,20 @@ def package_metainfo(factory):
     -----------
         factory: package name
     """
-    identifier = NotImplemented
+    identifier = ""
     name = factory.name
     description = factory.metainfo['description'] # optional no ask by ipm
     version = factory.metainfo['version']
     Authors = factory.metainfo['authors']
     url = factory.metainfo['url']
-    languages = NotImplemented
+    languages = ""
     organization = {"name" : factory.metainfo["institutes"], 
-                    "country" : NotImplemented, 
-                    "address" : NotImplemented, 
-                    "postal_code" : NotImplemented, 
-                    "city" : NotImplemented, 
-                    "email" : NotImplemented, 
-                    "url" : NotImplemented}
+                    "country" : "", 
+                    "address" : "", 
+                    "postal_code" : "", 
+                    "city" : "", 
+                    "email" : "", 
+                    "url" : ""}
     license = factory.metainfo['license'] # optional no ask by ipm
 
     return OrderedDict(identifier = identifier,
@@ -51,31 +51,31 @@ def package_metainfo(factory):
 def model_metainfo(factory,name):
     """Transform a factory into an OrderedDict"""
     name = factory[name].name
-    identifier = NotImplemented 
-    version = NotImplemented
-    type_of_decision = NotImplemented
-    type_of_output = NotImplemented
-    description_URL = NotImplemented
+    identifier = "" 
+    version = ""
+    type_of_decision = ""
+    type_of_output = ""
+    description_URL = ""
     description = factory[name].description
-    citation = NotImplemented
-    execution = {"type": NotImplemented,
-                "endpoints": NotImplemented,
-                "form_method": NotImplemented,
-                "content_type": NotImplemented,
-                "input_schema": NotImplemented} #factory[name].get_writer()}
+    citation = ""
+    execution = {"type": "",
+                "endpoints": "",
+                "form_method": "",
+                "content_type": "",
+                "input_schema": ""} #factory[name].get_writer()}
     inputs = factory[name].inputs
     authors = {"name":factory[name].get_authors(),
-            "email": NotImplemented,
+            "email": "",
             "organization":factory.metainfo["institutes"]}
-    pests = NotImplemented
-    crops = NotImplemented
-    keywords = NotImplemented
-    output = {"warning_status_interpretation": NotImplemented,
-            "result_parameters": {"id": NotImplemented , 
+    pests = ""
+    crops = ""
+    keywords = ""
+    output = {"warning_status_interpretation": "",
+            "result_parameters": {"id": "" , 
                                 "title": factory[name].outputs[0]['name'],
                                 "description": factory[name].outputs[0]['desc']}}
-    valid_spatial = {"countries": NotImplemented,
-                    "geoJson": NotImplemented}
+    valid_spatial = {"countries": "",
+                    "geoJson": ""}
     
     return OrderedDict(name = name, 
                        identifier = identifier, 


### PR DESCRIPTION
#   Convert automatically openalea meta information in json format according to JSON schema defined by IPM Decision

Creation of schema.py script used to convert automatically wralea metainformation in Json schema

## schema.py information

### Functions:
   * package_metainfo: Transform element of package metainfo on OrderedDict
   * model _metainfo: Transform element of model / module metainfo on OrderedDict
   * json_read: allows to print transformation of package and model metainfo OrderedDict in json schema
   * json_write: allows to generate json file issue to the conversion 

## Documentations 
* README.md: I begin to implement readme information for DSS repository

